### PR TITLE
Prevent duplicate category and language fetches

### DIFF
--- a/components/BodyContents.tsx
+++ b/components/BodyContents.tsx
@@ -1,21 +1,17 @@
 import Category from "./category";
 
-interface Categories {
+export interface CategoryItem {
   default_name: string;
   file_name: string;
+  image_url?: string;
 }
 
-interface CategoryList {
-  categoryList: Categories[];
+interface CategoryListProps {
+  categoryList: CategoryItem[];
 }
 
-function BodyContents({ categoryList }: CategoryList) {
-  return (
-    <>
-      {console.log(categoryList)}
-      <Category></Category>
-    </>
-  );
+function BodyContents({ categoryList }: CategoryListProps) {
+  return <Category categoryList={categoryList} />;
 }
 
 export default BodyContents;

--- a/components/category.tsx
+++ b/components/category.tsx
@@ -1,8 +1,12 @@
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper/modules";
+import type { CategoryItem } from "./BodyContents";
 
+interface CategoryProps {
+  categoryList: CategoryItem[];
+}
 
-function Category() {
+function Category({ categoryList }: CategoryProps) {
   return (
     <>
       <h2 className="text-center mt-3 mb-0">Menu</h2>
@@ -23,23 +27,24 @@ function Category() {
           },
         }}
       >
-        {/* {categoryList.map((item) => (
-          <p>{item.default_name}</p>
-        ))} */}
-        <SwiperSlide>
-          <div>
-            <img src="./c1.png"></img>
-            <p>Breakfast</p>
-          </div>
-        </SwiperSlide>
-        <SwiperSlide>Slide 2</SwiperSlide>
-        <SwiperSlide>Slide 3</SwiperSlide>
-        <SwiperSlide>Slide 4</SwiperSlide>
-        <SwiperSlide>Slide 5</SwiperSlide>
-        <SwiperSlide>Slide 6</SwiperSlide>
-        <SwiperSlide>Slide 7</SwiperSlide>
-        <SwiperSlide>Slide 8</SwiperSlide>
-        <SwiperSlide>Slide 9</SwiperSlide>
+        {categoryList.length > 0 ? (
+          categoryList.map((item) => (
+            <SwiperSlide key={item.file_name}>
+              <div>
+                {item.image_url ? (
+                  <img src={item.image_url} alt={item.default_name} />
+                ) : null}
+                <p>{item.default_name}</p>
+              </div>
+            </SwiperSlide>
+          ))
+        ) : (
+          <SwiperSlide>
+            <div>
+              <p className="text-center m-0">No categories available</p>
+            </div>
+          </SwiperSlide>
+        )}
       </Swiper>
     </>
   );


### PR DESCRIPTION
## Summary
- guard the language and category fetches so they only execute once and cancel safely when unmounted
- convert BodyContents and Category components to accept typed category data and render dynamic slides
- centralize category loading based on action changes and improve loading bar handling

## Testing
- not run (project does not include package.json to install dependencies)


------
https://chatgpt.com/codex/tasks/task_b_68dbc9714f008333abcc5b0095c7f21c